### PR TITLE
Tree layout mode for /explore

### DIFF
--- a/docs/superpowers/plans/2026-03-31-tree-layout.md
+++ b/docs/superpowers/plans/2026-03-31-tree-layout.md
@@ -1,0 +1,294 @@
+# Tree Layout Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Tree" layout mode to `/explore` that arranges family nodes in a classic top-down hierarchy using D3's tree algorithm.
+
+**Architecture:** A new `computeTreeLayout` function converts the flat `WheelNode[]` into a `d3.hierarchy`, runs `d3.tree()` for positioning, and returns a `Map<string, Position>` matching the existing layout interface. The FamilyWheel component gets a fourth layout button.
+
+**Tech Stack:** D3 (`d3.hierarchy`, `d3.tree`), TypeScript, Vitest, React
+
+**Spec:** `docs/superpowers/specs/2026-03-31-tree-layout-design.md`
+
+---
+
+## File Structure
+
+```
+src/lib/wheel-layouts.ts        — add computeTreeLayout, update computeBaselinePositions
+src/lib/wheel-layouts.test.ts   — add tree layout tests
+src/components/FamilyWheel.tsx   — add "tree" to LayoutMode, add button, wire layout
+```
+
+---
+
+### Task 1: Tree layout function with tests
+
+**Files:**
+- Modify: `src/lib/wheel-layouts.ts`
+- Modify: `src/lib/wheel-layouts.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests to `src/lib/wheel-layouts.test.ts`:
+
+```typescript
+import { computeTreeLayout } from "./wheel-layouts";
+
+// (at the bottom of the file, after existing describe blocks)
+
+describe("computeTreeLayout", () => {
+  it("places root node at top center", () => {
+    const nodes = [makeNode({ coupleId: "root", generation: 0, birthYear: 1919 })];
+    const positions = computeTreeLayout(nodes, 1919, 800, 800);
+    const root = positions.get("root")!;
+    expect(root.x).toBeCloseTo(0, 0);
+    expect(root.y).toBeLessThan(0);
+  });
+
+  it("places children below parent", () => {
+    const root = makeNode({ coupleId: "root", generation: 0, birthYear: 1919, childCount: 2 });
+    const child1 = makeNode({ coupleId: "c1", generation: 1, birthYear: 1945, birthOrder: 1, parentCoupleId: "root" });
+    const child2 = makeNode({ coupleId: "c2", generation: 1, birthYear: 1950, birthOrder: 2, parentCoupleId: "root" });
+    const positions = computeTreeLayout([root, child1, child2], 1919, 800, 800);
+
+    const rootPos = positions.get("root")!;
+    const c1Pos = positions.get("c1")!;
+    const c2Pos = positions.get("c2")!;
+
+    // Children should be below root (higher y in center-origin = below)
+    expect(c1Pos.y).toBeGreaterThan(rootPos.y);
+    expect(c2Pos.y).toBeGreaterThan(rootPos.y);
+  });
+
+  it("places siblings side by side horizontally", () => {
+    const root = makeNode({ coupleId: "root", generation: 0, birthYear: 1919, childCount: 2 });
+    const child1 = makeNode({ coupleId: "c1", generation: 1, birthYear: 1945, birthOrder: 1, parentCoupleId: "root" });
+    const child2 = makeNode({ coupleId: "c2", generation: 1, birthYear: 1950, birthOrder: 2, parentCoupleId: "root" });
+    const positions = computeTreeLayout([root, child1, child2], 1919, 800, 800);
+
+    const c1Pos = positions.get("c1")!;
+    const c2Pos = positions.get("c2")!;
+
+    // Siblings should be at the same y level
+    expect(c1Pos.y).toBeCloseTo(c2Pos.y, 0);
+    // And different x positions
+    expect(c1Pos.x).not.toBeCloseTo(c2Pos.x, 0);
+  });
+
+  it("places grandchildren below their parents", () => {
+    const root = makeNode({ coupleId: "root", generation: 0, birthYear: 1919, childCount: 1 });
+    const c1 = makeNode({ coupleId: "c1", generation: 1, birthYear: 1945, birthOrder: 1, parentCoupleId: "root", childCount: 1 });
+    const gc = makeNode({ coupleId: "gc1", generation: 2, birthYear: 1970, birthOrder: 1, parentCoupleId: "c1" });
+    const positions = computeTreeLayout([root, c1, gc], 1919, 800, 800);
+
+    const rootPos = positions.get("root")!;
+    const c1Pos = positions.get("c1")!;
+    const gcPos = positions.get("gc1")!;
+
+    expect(c1Pos.y).toBeGreaterThan(rootPos.y);
+    expect(gcPos.y).toBeGreaterThan(c1Pos.y);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/madsschmidt/Documents/fam/my_fam && pnpm vitest run src/lib/wheel-layouts.test.ts`
+Expected: FAIL — `computeTreeLayout` is not exported
+
+- [ ] **Step 3: Implement computeTreeLayout**
+
+Add this import at the top of `src/lib/wheel-layouts.ts`:
+
+```typescript
+import * as d3 from "d3";
+```
+
+Add this function before `computeBaselinePositions` in `src/lib/wheel-layouts.ts`:
+
+```typescript
+interface HierarchyDatum {
+  coupleId: string;
+  children: HierarchyDatum[];
+}
+
+function buildHierarchy(nodes: WheelNode[]): HierarchyDatum | null {
+  const root = nodes.find((n) => n.generation === 0);
+  if (!root) return null;
+
+  const childrenMap = new Map<string, WheelNode[]>();
+  for (const node of nodes) {
+    if (node.parentCoupleId) {
+      const siblings = childrenMap.get(node.parentCoupleId) ?? [];
+      siblings.push(node);
+      childrenMap.set(node.parentCoupleId, siblings);
+    }
+  }
+
+  function toDatum(node: WheelNode): HierarchyDatum {
+    const children = (childrenMap.get(node.coupleId) ?? [])
+      .sort((a, b) => a.birthOrder - b.birthOrder)
+      .map(toDatum);
+    return { coupleId: node.coupleId, children };
+  }
+
+  return toDatum(root);
+}
+
+export function computeTreeLayout(
+  nodes: WheelNode[],
+  _rootBirthYear: number,
+  width: number,
+  height: number,
+): Map<string, Position> {
+  const positions = new Map<string, Position>();
+  const datum = buildHierarchy(nodes);
+  if (!datum) return positions;
+
+  const padding = 40;
+  const root = d3.hierarchy(datum);
+  const treeLayout = d3.tree<HierarchyDatum>().size([
+    width - padding * 2,
+    height - padding * 2,
+  ]);
+  treeLayout(root);
+
+  // d3.tree sets x = horizontal spread, y = depth
+  // Convert to center-origin: subtract center offsets
+  const cx = width / 2;
+  const cy = height / 2;
+
+  for (const descendant of root.descendants()) {
+    positions.set(descendant.data.coupleId, {
+      x: (descendant.x ?? 0) + padding - cx,
+      y: (descendant.y ?? 0) + padding - cy,
+    });
+  }
+
+  return positions;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/madsschmidt/Documents/fam/my_fam && pnpm vitest run src/lib/wheel-layouts.test.ts`
+Expected: All tests PASS (existing + 4 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/wheel-layouts.ts src/lib/wheel-layouts.test.ts
+git commit -m "feat: add computeTreeLayout using d3.tree()"
+```
+
+---
+
+### Task 2: Update computeBaselinePositions and LayoutMode
+
+**Files:**
+- Modify: `src/lib/wheel-layouts.ts`
+- Modify: `src/components/FamilyWheel.tsx`
+
+- [ ] **Step 1: Add "tree" case to computeBaselinePositions**
+
+In `src/lib/wheel-layouts.ts`, change the `computeBaselinePositions` function signature and body:
+
+Change the `layoutMode` parameter type from:
+```typescript
+  layoutMode: "wheel" | "birthOrder" | "branchSize",
+```
+To:
+```typescript
+  layoutMode: "wheel" | "birthOrder" | "branchSize" | "tree",
+```
+
+Add a new case before the `default` in the switch:
+```typescript
+    case "tree":
+      positions = computeTreeLayout(nodes, rootBirthYear, width, height);
+      break;
+```
+
+- [ ] **Step 2: Update LayoutMode type in FamilyWheel.tsx**
+
+In `src/components/FamilyWheel.tsx`, change:
+```typescript
+type LayoutMode = "wheel" | "birthOrder" | "branchSize";
+```
+To:
+```typescript
+type LayoutMode = "wheel" | "birthOrder" | "branchSize" | "tree";
+```
+
+- [ ] **Step 3: Add tree to getLayout callback**
+
+In `src/components/FamilyWheel.tsx`, add the import for `computeTreeLayout`:
+
+Change the import from `@/lib/wheel-layouts` to include `computeTreeLayout`:
+```typescript
+import {
+  computeWheelLayout,
+  computeBirthOrderLayout,
+  computeBranchSizeLayout,
+  computeTreeLayout,
+  computeBaselinePositions,
+} from "@/lib/wheel-layouts";
+```
+
+In the `getLayout` callback, add a case for `"tree"` before the `default`:
+```typescript
+  const getLayout = useCallback(
+    (nodes: WheelNode[], width: number, height: number) => {
+      const rootBirthYear = nodes.find((n) => n.generation === 0)?.birthYear ?? 1919;
+      switch (layoutMode) {
+        case "birthOrder":
+          return computeBirthOrderLayout(nodes, rootBirthYear, width, height);
+        case "branchSize":
+          return computeBranchSizeLayout(nodes, rootBirthYear, width, height);
+        case "tree":
+          return computeTreeLayout(nodes, rootBirthYear, width, height);
+        default:
+          return computeWheelLayout(nodes, rootBirthYear, width, height);
+      }
+    },
+    [layoutMode],
+  );
+```
+
+- [ ] **Step 4: Add the Tree button to the layout mode button bar**
+
+In `src/components/FamilyWheel.tsx`, find the array of layout buttons:
+```typescript
+        {(["wheel", "birthOrder", "branchSize"] as const).map((mode) => (
+```
+Change to:
+```typescript
+        {(["wheel", "birthOrder", "branchSize", "tree"] as const).map((mode) => (
+```
+
+And update the label mapping inside the button text. Find:
+```typescript
+            {mode === "wheel" ? "Wheel" : mode === "birthOrder" ? "Birth Order" : "Branch Size"}
+```
+Change to:
+```typescript
+            {mode === "wheel" ? "Wheel" : mode === "birthOrder" ? "Birth Order" : mode === "branchSize" ? "Branch Size" : "Tree"}
+```
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cd /Users/madsschmidt/Documents/fam/my_fam && pnpm vitest run`
+Expected: All tests PASS
+
+- [ ] **Step 6: Run the build**
+
+Run: `cd /Users/madsschmidt/Documents/fam/my_fam && pnpm build`
+Expected: Build succeeds with no TypeScript errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/wheel-layouts.ts src/components/FamilyWheel.tsx
+git commit -m "feat: add Tree layout mode to /explore"
+```

--- a/docs/superpowers/specs/2026-03-31-tree-layout-design.md
+++ b/docs/superpowers/specs/2026-03-31-tree-layout-design.md
@@ -1,0 +1,55 @@
+# Tree Layout Mode
+
+## Problem
+
+The `/explore` page has three radial layout modes (wheel, birth order, branch size) but no classic top-down family tree view. Users expect to be able to see their family as a traditional hierarchy.
+
+## Solution
+
+Add a fourth layout mode, "Tree," to the existing layout switcher on `/explore`. Uses D3's `d3.tree()` algorithm to compute top-down hierarchical positions. Nodes animate from their current positions into the tree arrangement via the existing D3 force simulation.
+
+## Layout Algorithm
+
+1. Convert the flat `WheelNode[]` array into a `d3.hierarchy` tree by walking `parentCoupleId` relationships from the root node (generation 0)
+2. Run `d3.tree().size([width - padding, height - padding])` to compute positions. D3's tree layout assigns `x` as horizontal spread within siblings and `y` as depth (generation level), which maps directly to the top-down orientation.
+3. Convert the D3 hierarchy positions back to `Map<string, Position>` in center-origin coordinates, matching the interface of the existing layout functions (`computeWheelLayout` etc.)
+
+The root couple appears at the top center. Each generation occupies a horizontal row below. Siblings are spaced evenly within their parent's subtree width. D3's tree algorithm handles subtree separation to avoid overlap.
+
+## Integration
+
+### LayoutMode type
+
+Expand from `"wheel" | "birthOrder" | "branchSize"` to include `"tree"`.
+
+### wheel-layouts.ts
+
+Add `computeTreeLayout(nodes, rootBirthYear, width, height)` returning `Map<string, Position>`. Same signature as the existing layout functions.
+
+Update `computeBaselinePositions` with a `"tree"` case.
+
+### FamilyWheel.tsx
+
+- Add `"tree"` case to `getLayout` callback
+- Add a "Tree" button to the layout mode button bar
+- No other changes — the layout switch effect already handles unpinning nodes, retargeting forces, and restarting the simulation
+
+### Shareable view state
+
+No changes needed. The view-state lib already encodes `settings.layout` in the URL. A shared link with `layout: "tree"` restores directly into tree view. `computeBaselinePositions` provides the deterministic baseline via the new `"tree"` case.
+
+## What stays the same
+
+- Same node representation (single circle per couple)
+- Same straight lines between nodes
+- Same zoom, drag, labels, decade rings, hover tooltips, edit mode, share button
+- Same D3 force simulation for animation
+- Same page (`/explore`), same component (`FamilyWheel`)
+
+## Out of scope
+
+- Collapsible subtrees
+- Different node shapes or sizes for tree mode
+- Org-chart style connectors (horizontal bars + vertical drops)
+- Separate tree-specific rendering path
+- New page or route

--- a/src/components/FamilyWheel.tsx
+++ b/src/components/FamilyWheel.tsx
@@ -6,6 +6,7 @@ import {
   computeWheelLayout,
   computeBirthOrderLayout,
   computeBranchSizeLayout,
+  computeTreeLayout,
   computeBaselinePositions,
 } from "@/lib/wheel-layouts";
 import { useShareableView } from "@/lib/view-state";
@@ -20,7 +21,7 @@ import SyncBadge from "./SyncBadge";
 const GEN_COLORS = ["#f59e0b", "#3b82f6", "#10b981", "#8b5cf6"];
 const GEN_RADII = [22, 15, 12, 10];
 
-type LayoutMode = "wheel" | "birthOrder" | "branchSize";
+type LayoutMode = "wheel" | "birthOrder" | "branchSize" | "tree";
 
 interface Props {
   familyData: FamilyData;
@@ -59,6 +60,8 @@ export default function FamilyWheel({ familyData, rootCoupleId }: Props) {
           return computeBirthOrderLayout(nodes, rootBirthYear, width, height);
         case "branchSize":
           return computeBranchSizeLayout(nodes, rootBirthYear, width, height);
+        case "tree":
+          return computeTreeLayout(nodes, rootBirthYear, width, height);
         default:
           return computeWheelLayout(nodes, rootBirthYear, width, height);
       }
@@ -513,7 +516,7 @@ export default function FamilyWheel({ familyData, rootCoupleId }: Props) {
 
       {/* Layout mode buttons + label toggle */}
       <div className="absolute top-5 right-5 z-10 flex gap-2">
-        {(["wheel", "birthOrder", "branchSize"] as const).map((mode) => (
+        {(["wheel", "birthOrder", "branchSize", "tree"] as const).map((mode) => (
           <button
             key={mode}
             onClick={() => setLayoutMode(mode)}
@@ -523,7 +526,7 @@ export default function FamilyWheel({ familyData, rootCoupleId }: Props) {
                 : "bg-[#1e2030] border-[#2a2d3e] text-gray-400 hover:bg-[#2a2d3e] hover:text-white"
             }`}
           >
-            {mode === "wheel" ? "Hjul" : mode === "birthOrder" ? "Fodselsdato" : "Grenstorrelse"}
+            {mode === "wheel" ? "Hjul" : mode === "birthOrder" ? "Fodselsdato" : mode === "branchSize" ? "Grenstorrelse" : "Trae"}
           </button>
         ))}
         <button

--- a/src/lib/wheel-layouts.test.ts
+++ b/src/lib/wheel-layouts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeWheelLayout, computeBirthOrderLayout, computeBranchSizeLayout } from "./wheel-layouts";
+import { computeWheelLayout, computeBirthOrderLayout, computeBranchSizeLayout, computeTreeLayout } from "./wheel-layouts";
 import type { WheelNode } from "./wheel-graph";
 
 function makeNode(overrides: Partial<WheelNode>): WheelNode {
@@ -85,5 +85,56 @@ describe("computeBranchSizeLayout", () => {
     });
     const gcSpan = Math.max(...gcAngles) - Math.min(...gcAngles);
     expect(gcSpan).toBeGreaterThan(0);
+  });
+});
+
+describe("computeTreeLayout", () => {
+  it("places root node at top center", () => {
+    const nodes = [makeNode({ coupleId: "root", generation: 0, birthYear: 1919 })];
+    const positions = computeTreeLayout(nodes, 1919, 800, 800);
+    const root = positions.get("root")!;
+    expect(root.x).toBeCloseTo(0, 0);
+    expect(root.y).toBeLessThan(0);
+  });
+
+  it("places children below parent", () => {
+    const root = makeNode({ coupleId: "root", generation: 0, birthYear: 1919, childCount: 2 });
+    const child1 = makeNode({ coupleId: "c1", generation: 1, birthYear: 1945, birthOrder: 1, parentCoupleId: "root" });
+    const child2 = makeNode({ coupleId: "c2", generation: 1, birthYear: 1950, birthOrder: 2, parentCoupleId: "root" });
+    const positions = computeTreeLayout([root, child1, child2], 1919, 800, 800);
+
+    const rootPos = positions.get("root")!;
+    const c1Pos = positions.get("c1")!;
+    const c2Pos = positions.get("c2")!;
+
+    expect(c1Pos.y).toBeGreaterThan(rootPos.y);
+    expect(c2Pos.y).toBeGreaterThan(rootPos.y);
+  });
+
+  it("places siblings side by side horizontally", () => {
+    const root = makeNode({ coupleId: "root", generation: 0, birthYear: 1919, childCount: 2 });
+    const child1 = makeNode({ coupleId: "c1", generation: 1, birthYear: 1945, birthOrder: 1, parentCoupleId: "root" });
+    const child2 = makeNode({ coupleId: "c2", generation: 1, birthYear: 1950, birthOrder: 2, parentCoupleId: "root" });
+    const positions = computeTreeLayout([root, child1, child2], 1919, 800, 800);
+
+    const c1Pos = positions.get("c1")!;
+    const c2Pos = positions.get("c2")!;
+
+    expect(c1Pos.y).toBeCloseTo(c2Pos.y, 0);
+    expect(c1Pos.x).not.toBeCloseTo(c2Pos.x, 0);
+  });
+
+  it("places grandchildren below their parents", () => {
+    const root = makeNode({ coupleId: "root", generation: 0, birthYear: 1919, childCount: 1 });
+    const c1 = makeNode({ coupleId: "c1", generation: 1, birthYear: 1945, birthOrder: 1, parentCoupleId: "root", childCount: 1 });
+    const gc = makeNode({ coupleId: "gc1", generation: 2, birthYear: 1970, birthOrder: 1, parentCoupleId: "c1" });
+    const positions = computeTreeLayout([root, c1, gc], 1919, 800, 800);
+
+    const rootPos = positions.get("root")!;
+    const c1Pos = positions.get("c1")!;
+    const gcPos = positions.get("gc1")!;
+
+    expect(c1Pos.y).toBeGreaterThan(rootPos.y);
+    expect(gcPos.y).toBeGreaterThan(c1Pos.y);
   });
 });

--- a/src/lib/wheel-layouts.ts
+++ b/src/lib/wheel-layouts.ts
@@ -208,7 +208,7 @@ export function computeTreeLayout(
  */
 export function computeBaselinePositions(
   nodes: WheelNode[],
-  layoutMode: "wheel" | "birthOrder" | "branchSize",
+  layoutMode: "wheel" | "birthOrder" | "branchSize" | "tree",
   width: number,
   height: number,
 ): Map<string, { x: number; y: number }> {
@@ -220,6 +220,9 @@ export function computeBaselinePositions(
       break;
     case "branchSize":
       positions = computeBranchSizeLayout(nodes, rootBirthYear, width, height);
+      break;
+    case "tree":
+      positions = computeTreeLayout(nodes, rootBirthYear, width, height);
       break;
     default:
       positions = computeWheelLayout(nodes, rootBirthYear, width, height);

--- a/src/lib/wheel-layouts.ts
+++ b/src/lib/wheel-layouts.ts
@@ -1,3 +1,4 @@
+import * as d3 from "d3";
 import type { WheelNode } from "./wheel-graph";
 
 export interface Position {
@@ -136,6 +137,67 @@ export function computeBranchSizeLayout(
     const angle = angles.get(node.coupleId) ?? 0;
     const radius = birthYearToRadius(node.birthYear, rootBirthYear, scale);
     positions.set(node.coupleId, polarToCartesian(angle, radius));
+  }
+
+  return positions;
+}
+
+interface HierarchyDatum {
+  coupleId: string;
+  children: HierarchyDatum[];
+}
+
+function buildHierarchy(nodes: WheelNode[]): HierarchyDatum | null {
+  const root = nodes.find((n) => n.generation === 0);
+  if (!root) return null;
+
+  const childrenMap = new Map<string, WheelNode[]>();
+  for (const node of nodes) {
+    if (node.parentCoupleId) {
+      const siblings = childrenMap.get(node.parentCoupleId) ?? [];
+      siblings.push(node);
+      childrenMap.set(node.parentCoupleId, siblings);
+    }
+  }
+
+  function toDatum(node: WheelNode): HierarchyDatum {
+    const children = (childrenMap.get(node.coupleId) ?? [])
+      .sort((a, b) => a.birthOrder - b.birthOrder)
+      .map(toDatum);
+    return { coupleId: node.coupleId, children };
+  }
+
+  return toDatum(root);
+}
+
+export function computeTreeLayout(
+  nodes: WheelNode[],
+  _rootBirthYear: number,
+  width: number,
+  height: number,
+): Map<string, Position> {
+  const positions = new Map<string, Position>();
+  const datum = buildHierarchy(nodes);
+  if (!datum) return positions;
+
+  const padding = 40;
+  const root = d3.hierarchy(datum);
+  const treeLayout = d3.tree<HierarchyDatum>().size([
+    width - padding * 2,
+    height - padding * 2,
+  ]);
+  treeLayout(root);
+
+  // d3.tree sets x = horizontal spread, y = depth
+  // Convert to center-origin: subtract center offsets
+  const cx = width / 2;
+  const cy = height / 2;
+
+  for (const descendant of root.descendants()) {
+    positions.set(descendant.data.coupleId, {
+      x: (descendant.x ?? 0) + padding - cx,
+      y: (descendant.y ?? 0) + padding - cy,
+    });
   }
 
   return positions;


### PR DESCRIPTION
## Summary

- New "Tree" layout mode on `/explore` using D3's `d3.tree()` algorithm
- Top-down hierarchical arrangement: root at top, generations flow downward, siblings side by side
- Added as a fourth button alongside Wheel/Birth Order/Branch Size
- Nodes animate between layouts via the existing D3 force simulation
- Shareable view state works out of the box (baseline + diff)

## Architecture

One new function `computeTreeLayout` in `wheel-layouts.ts`:
1. Converts flat `WheelNode[]` → `d3.hierarchy` via `parentCoupleId` relationships
2. Runs `d3.tree()` for position computation
3. Returns `Map<string, Position>` in center-origin coords (same interface as existing layouts)

4 new tests for tree-specific positioning (root at top, children below, siblings horizontal, grandchildren depth).

## Test plan

- [x] 64 tests pass (4 new tree layout tests + all existing)
- [x] Production build succeeds
- [ ] Manual: click "Tree" button → nodes animate into top-down hierarchy
- [ ] Manual: switch back to "Wheel" → nodes animate back to radial layout
- [ ] Manual: share a tree view URL → recipient sees tree layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)